### PR TITLE
[Bugfix] Issue dispatching files with spaces

### DIFF
--- a/src/Dispatch.php
+++ b/src/Dispatch.php
@@ -175,6 +175,9 @@ class Dispatch implements HttpKernelInterface
       //What resources do you expect to find with no path?
       return $this->invalidUrlResponse();
     }
+    
+    //decode so we can match filename on the filesystem
+    $path = urldecode($path);
 
     $pathInfo = pathinfo($path);
 


### PR DESCRIPTION
This pull request fixes an issue where assets with spaces (or other url encoded chars) in the file name are not served correctly.

E.g. /assets/p/19bd8/b/e5642c8//uploads/example%20file%201.jpg

The issue was caused because the request path is still encoded and when file_exists() looks for the encoded path it doesn't find a file.